### PR TITLE
Migrate to Java 8 runtime

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -2,6 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
     <application>your-app-id</application>
     <version>v1</version>
+    <runtime>java8</runtime>
     <threadsafe>true</threadsafe>
 
     <system-properties>


### PR DESCRIPTION
Google Cloud Console kept showing a warning that 'Java 7 runtime is deprecated'.  [Their docs](https://cloud.google.com/appengine/docs/deprecations/java7?hl=en_US&_ga=2.171157152.-1043945360.1528606035) say it'll be shut down entirely on January 16, 2019.

I just specified the new runtime in `appengine-web.xml` and tested it on my own instance.