### PR TITLE
change 'com.google.appengine.tools:appengine-gcs-client' version to 0.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile "org.glassfish.jersey:jersey-bom:$jerseyVersion"
     compile "org.glassfish.jersey.containers:jersey-container-servlet:$jerseyVersion"
     compile "org.glassfish.jersey.ext:jersey-mvc-mustache:$jerseyVersion"
-    compile 'com.google.appengine.tools:appengine-gcs-client:0.6'
+    compile 'com.google.appengine.tools:appengine-gcs-client:0.8'
     compile 'org.slf4j:slf4j-jdk14:1.7.18'
 }
 


### PR DESCRIPTION
In order to avoid exception:

Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find androidx.annotation:annotation:1.1.0.
Searched in the following locations:
  - https://jcenter.bintray.com/androidx/annotation/annotation/1.1.0/annotation-1.1.0.pom
  - https://jcenter.bintray.com/androidx/annotation/annotation/1.1.0/annotation-1.1.0.jar
Required by:
    project : > com.google.appengine.tools:appengine-gcs-client:0.6 > com.google.apis:google-api-services-storage:v1-rev68-1.21.0 > com.google.api-client:google-api-client:1.30.8